### PR TITLE
Add GitHub action workflow to build on Windows

### DIFF
--- a/.github/workflows/msbuild.yml
+++ b/.github/workflows/msbuild.yml
@@ -1,0 +1,32 @@
+name: MSBuild
+
+on: [push]
+
+env:
+  # Path to the solution file relative to the root of the project.
+  SOLUTION_FILE_PATH: .
+
+  # Configuration type to build.
+  # You can convert this to a build matrix if you need coverage of multiple configuration types.
+  # https://docs.github.com/actions/learn-github-actions/managing-complex-workflows#using-a-build-matrix
+  BUILD_CONFIGURATION: Release
+
+jobs:
+  build:
+    runs-on: windows-latest
+
+    steps:
+    - uses: actions/checkout@v2
+
+    - name: Add MSBuild to PATH
+      uses: microsoft/setup-msbuild@v1.0.2
+
+    - name: Restore NuGet packages
+      working-directory: ${{env.GITHUB_WORKSPACE}}
+      run: nuget restore ${{env.SOLUTION_FILE_PATH}}
+
+    - name: Build
+      working-directory: ${{env.GITHUB_WORKSPACE}}
+      # Add additional options to the MSBuild command line here (like platform or verbosity level).
+      # See https://docs.microsoft.com/visualstudio/msbuild/msbuild-command-line-reference
+      run: msbuild /m /p:Configuration=${{env.BUILD_CONFIGURATION}} ${{env.SOLUTION_FILE_PATH}}

--- a/.github/workflows/msbuild.yml
+++ b/.github/workflows/msbuild.yml
@@ -21,10 +21,6 @@ jobs:
     - name: Add MSBuild to PATH
       uses: microsoft/setup-msbuild@v1.0.2
 
-    - name: Restore NuGet packages
-      working-directory: ${{env.GITHUB_WORKSPACE}}
-      run: nuget restore ${{env.SOLUTION_FILE_PATH}}
-
     - name: Build
       working-directory: ${{env.GITHUB_WORKSPACE}}
       # Add additional options to the MSBuild command line here (like platform or verbosity level).

--- a/.github/workflows/msbuild.yml
+++ b/.github/workflows/msbuild.yml
@@ -9,7 +9,7 @@ env:
   # Configuration type to build.
   # You can convert this to a build matrix if you need coverage of multiple configuration types.
   # https://docs.github.com/actions/learn-github-actions/managing-complex-workflows#using-a-build-matrix
-  BUILD_CONFIGURATION: Release
+  BUILD_CONFIGURATION: Debug
 
 jobs:
   build:

--- a/.github/workflows/msbuild.yml
+++ b/.github/workflows/msbuild.yml
@@ -1,6 +1,6 @@
 name: MSBuild
 
-on: [push]
+on: [push, pull_request]
 
 env:
   # Path to the solution file relative to the root of the project.

--- a/.github/workflows/msbuild.yml
+++ b/.github/workflows/msbuild.yml
@@ -21,6 +21,18 @@ jobs:
     - name: Add MSBuild to PATH
       uses: microsoft/setup-msbuild@v1.0.2
 
+    - name: Set environment variables
+      shell: cmd
+      run: |
+        echo PGDIR=%GITHUB_WORKSPACE%\postgres-binaries\pgsql>> %GITHUB_ENV%
+
+    - name: Download and unpack PostgreSQL
+      working-directory: ${{env.GITHUB_WORKSPACE}}
+      shell: pwsh
+      run: |
+        Invoke-WebRequest -Uri "https://get.enterprisedb.com/postgresql/postgresql-9.2.24-1-windows-binaries.zip?ls=Crossover&type=Crossover" -OutFile postgres-binaries.zip
+        7z.exe x postgres-binaries.zip -o${{env.PGDIR}}\..
+
     - name: Build
       working-directory: ${{env.GITHUB_WORKSPACE}}
       # Add additional options to the MSBuild command line here (like platform or verbosity level).

--- a/.github/workflows/msbuild.yml
+++ b/.github/workflows/msbuild.yml
@@ -24,7 +24,22 @@ jobs:
     - name: Set environment variables
       shell: cmd
       run: |
+        echo WXWIN=%GITHUB_WORKSPACE%\wxWidgets>> %GITHUB_ENV%
         echo PGDIR=%GITHUB_WORKSPACE%\postgres-binaries\pgsql>> %GITHUB_ENV%
+
+    - name: Download and unpack wxWidgets headers
+      working-directory: ${{env.GITHUB_WORKSPACE}}
+      shell: pwsh
+      run: |
+        Invoke-WebRequest -Uri "https://github.com/wxWidgets/wxWidgets/releases/download/v3.0.5/wxWidgets-3.0.5-headers.7z" -OutFile wxWidgets-headers.7z
+        7z.exe x wxWidgets-headers.7z -o${{env.WXWIN}}
+
+    - name: Download and unpack wxWidgets developer files
+      working-directory: ${{env.GITHUB_WORKSPACE}}
+      shell: pwsh
+      run: |
+        Invoke-WebRequest -Uri "https://github.com/wxWidgets/wxWidgets/releases/download/v3.0.5/wxMSW-3.0.5_vc142_Dev.7z" -OutFile wxWidgets-devel.7z
+        7z.exe x wxWidgets-devel.7z -o${{env.WXWIN}}
 
     - name: Download and unpack PostgreSQL
       working-directory: ${{env.GITHUB_WORKSPACE}}


### PR DESCRIPTION
This PR adds a [github action](https://docs.github.com/en/actions) workflow that builds pgAdmin on Windows for every pushed branch and for every pull request.

As of now only a Debug-build is performed. This is because the Release-build also includes the documentation and the installer. The installer still has some issues that will be fixed in an upcoming PR. That PR will then also include upgrades to the workflow so that it will successfully build in Debug- and Release-mode.

I assume workflows are not yet activated for this repo, therefore we do not see an actual workflow run for this PR. You can however take look at [the workflow run in my fork](https://github.com/SebDieBln/pgadmin3-lts/actions/runs/1705579485).