### PR TITLE
Fix the windows installer

### DIFF
--- a/.github/workflows/msbuild.yml
+++ b/.github/workflows/msbuild.yml
@@ -27,6 +27,11 @@ jobs:
         echo WXWIN=%GITHUB_WORKSPACE%\wxWidgets>> %GITHUB_ENV%
         echo PGDIR=%GITHUB_WORKSPACE%\postgres-binaries\pgsql>> %GITHUB_ENV%
 
+    - name: Install sphinx
+      if: ${{ matrix.build_conf == 'Release' }}
+      shell: cmd
+      run: pip install Sphinx
+
     - name: Download and unpack wxWidgets headers
       if: ${{ matrix.build_conf != 'Release' }}
       working-directory: ${{env.GITHUB_WORKSPACE}}

--- a/.github/workflows/msbuild.yml
+++ b/.github/workflows/msbuild.yml
@@ -13,7 +13,7 @@ env:
 
 jobs:
   build:
-    runs-on: windows-latest
+    runs-on: windows-2019
 
     steps:
     - uses: actions/checkout@v2

--- a/.github/workflows/msbuild.yml
+++ b/.github/workflows/msbuild.yml
@@ -28,11 +28,20 @@ jobs:
         echo PGDIR=%GITHUB_WORKSPACE%\postgres-binaries\pgsql>> %GITHUB_ENV%
 
     - name: Download and unpack wxWidgets headers
+      if: ${{ matrix.build_conf != 'Release' }}
       working-directory: ${{env.GITHUB_WORKSPACE}}
       shell: pwsh
       run: |
         Invoke-WebRequest -Uri "https://github.com/wxWidgets/wxWidgets/releases/download/v3.0.5/wxWidgets-3.0.5-headers.7z" -OutFile wxWidgets-headers.7z
         7z.exe x wxWidgets-headers.7z -o${{env.WXWIN}}
+
+    - name: Download and unpack wxWidgets source
+      if: ${{ matrix.build_conf == 'Release' }}
+      working-directory: ${{env.GITHUB_WORKSPACE}}
+      shell: pwsh
+      run: |
+        Invoke-WebRequest -Uri "https://github.com/wxWidgets/wxWidgets/releases/download/v3.0.5/wxWidgets-3.0.5.7z" -OutFile wxWidgets-source.7z
+        7z.exe x wxWidgets-source.7z -o${{env.WXWIN}}
 
     - name: Download and unpack wxWidgets developer files
       working-directory: ${{env.GITHUB_WORKSPACE}}
@@ -41,12 +50,35 @@ jobs:
         Invoke-WebRequest -Uri "https://github.com/wxWidgets/wxWidgets/releases/download/v3.0.5/wxMSW-3.0.5_vc142_Dev.7z" -OutFile wxWidgets-devel.7z
         7z.exe x wxWidgets-devel.7z -o${{env.WXWIN}}
 
+    - name: Download and unpack wxWidgets release libraries
+      if: ${{ matrix.build_conf == 'Release' }}
+      working-directory: ${{env.GITHUB_WORKSPACE}}
+      shell: pwsh
+      run: |
+        Invoke-WebRequest -Uri "https://github.com/wxWidgets/wxWidgets/releases/download/v3.0.5/wxMSW-3.0.5_vc142_ReleaseDLL.7z" -OutFile wxWidgets-libraries.7z
+        7z.exe x wxWidgets-libraries.7z -o${{env.WXWIN}}
+
     - name: Download and unpack PostgreSQL
       working-directory: ${{env.GITHUB_WORKSPACE}}
       shell: pwsh
       run: |
         Invoke-WebRequest -Uri "https://get.enterprisedb.com/postgresql/postgresql-9.2.24-1-windows-binaries.zip?ls=Crossover&type=Crossover" -OutFile postgres-binaries.zip
         7z.exe x postgres-binaries.zip -o${{env.PGDIR}}\..
+
+    - name: Set up Visual Studio shell
+      if: ${{ matrix.build_conf == 'Release' }}
+      uses: egor-tensin/vs-shell@v2
+      with:
+        arch: x86
+
+    - name: Build hhp2cached
+      if: ${{ matrix.build_conf == 'Release' }}
+      working-directory: ${{env.WXWIN}}\utils\hhp2cached
+      shell: cmd
+      run: |
+        echo SHARED = 1 >> ..\..\build\msw\config.vc
+        echo BUILD = release>> ..\..\build\msw\config.vc
+        nmake -f makefile.vc COMPILER_VERSION=142
 
     - name: Build
       working-directory: ${{env.GITHUB_WORKSPACE}}

--- a/.github/workflows/msbuild.yml
+++ b/.github/workflows/msbuild.yml
@@ -6,14 +6,14 @@ env:
   # Path to the solution file relative to the root of the project.
   SOLUTION_FILE_PATH: .
 
-  # Configuration type to build.
-  # You can convert this to a build matrix if you need coverage of multiple configuration types.
-  # https://docs.github.com/actions/learn-github-actions/managing-complex-workflows#using-a-build-matrix
-  BUILD_CONFIGURATION: Debug
-
 jobs:
   build:
     runs-on: windows-2019
+
+    strategy:
+      fail-fast: false
+      matrix:
+        build_conf: [Release, Debug]
 
     steps:
     - uses: actions/checkout@v2
@@ -52,4 +52,4 @@ jobs:
       working-directory: ${{env.GITHUB_WORKSPACE}}
       # Add additional options to the MSBuild command line here (like platform or verbosity level).
       # See https://docs.microsoft.com/visualstudio/msbuild/msbuild-command-line-reference
-      run: msbuild /m /p:Configuration=${{env.BUILD_CONFIGURATION}} ${{env.SOLUTION_FILE_PATH}}
+      run: msbuild /m /p:Configuration=${{matrix.build_conf}} ${{env.SOLUTION_FILE_PATH}}

--- a/INSTALL
+++ b/INSTALL
@@ -140,7 +140,7 @@ You will need:
 - Windows 10 or above.
 - Microsoft Visual C++ 2022.
 - The Windows 10 Platform SDK.
-- Windows Installer XML v3.
+- WiX toolset v3 from https://wixtoolset.org/
 - wxMSW 3.0.5 or above from http://www.wxwidgets.org/
   If you only want to build the pgAdmin3 binary you need the packages
    - Header Files

--- a/INSTALL
+++ b/INSTALL
@@ -138,7 +138,7 @@ Windows
 You will need:
 
 - Windows 10 or above.
-- Microsoft Visual C++ 2022.
+- Microsoft Visual C++ 2019.
 - The Windows 10 Platform SDK.
 - WiX toolset v3 from https://wixtoolset.org/
 - wxMSW 3.0.5 or above from http://www.wxwidgets.org/

--- a/docs/Docs.vcxproj
+++ b/docs/Docs.vcxproj
@@ -26,7 +26,7 @@
   <PropertyGroup>
     <_ProjectFileVersion>10.0.30319.1</_ProjectFileVersion>
     <OutDir Condition="'$(Configuration)|$(Platform)'=='All|Win32'">$(SolutionDir)</OutDir>
-    <IntDir Condition="'$(Configuration)|$(Platform)'=='All|Win32'">$(SolutionDir)</IntDir>
+    <IntDir Condition="'$(Configuration)|$(Platform)'=='All|Win32'">$(ProjectDir)$(Configuration)\</IntDir>
   </PropertyGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='All|Win32'">
     <CustomBuildStep>

--- a/pkg/win32/Installer.vcxproj
+++ b/pkg/win32/Installer.vcxproj
@@ -26,7 +26,7 @@
   <PropertyGroup>
     <_ProjectFileVersion>10.0.30319.1</_ProjectFileVersion>
     <OutDir Condition="'$(Configuration)|$(Platform)'=='All|Win32'">$(SolutionDir)</OutDir>
-    <IntDir Condition="'$(Configuration)|$(Platform)'=='All|Win32'">$(SolutionDir)</IntDir>
+    <IntDir Condition="'$(Configuration)|$(Platform)'=='All|Win32'">$(ProjectDir)$(Configuration)\</IntDir>
   </PropertyGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='All|Win32'">
     <CustomBuildStep>

--- a/pkg/win32/Installer.vcxproj
+++ b/pkg/win32/Installer.vcxproj
@@ -31,7 +31,7 @@
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='All|Win32'">
     <CustomBuildStep>
       <Message>Calling installer build script...</Message>
-      <Command>make.bat 1.23 $(PlatformToolsetVersion)</Command>
+      <Command>make.bat 1.23 $(PlatformToolsetVersion) "$(VCToolsRedistInstallDir)."</Command>
       <Outputs>.\pgadmin3.msi;%(Outputs)</Outputs>
     </CustomBuildStep>
     <Link>

--- a/pkg/win32/Make.bat
+++ b/pkg/win32/Make.bat
@@ -1,4 +1,4 @@
-@echo off
+@echo on
 
 REM
 REM Setup the following values as required for the installation
@@ -49,12 +49,12 @@ GOTO EXIT
 
 :BUILD_PACKAGE
 
-if "%2"=="" GOTO ERR_USAGE
+if (%3)==() GOTO ERR_USAGE
 
 echo.
 echo Building %APPNAME% Installer...
 
-"%WIX%\bin\candle" -nologo -dWXDIR="%WXWIN%" -dPLATFORM_TOOLSET_VERSION=%2 -dPGDIR="%PGDIR%" -dBUILDTREE="%BUILDTREE%" -dBRANDED=%BRANDED% -dBRANDINGDIR="%BRANDINGDIR%" -dAPPVENDOR="%APPVENDOR%" -dAPPNAME="%APPNAME%" -dAPPKEYWORDS="%APPKEYWORDS%" -dAPPCOMMENTS="%APPCOMMENTS%" -dAPPDESCRIPTION="%APPDESCRIPTION%" -dAPPVERSION="%1" -dSYSTEM32DIR="%SystemRoot%\System32" -dPFILESDIR="%ProgramFiles%" src/pgadmin3.wxs
+"%WIX%\bin\candle" -nologo -dWXDIR="%WXWIN%" -dPLATFORM_TOOLSET_VERSION=%2 -dVC_TOOLS_REDIST_INSTALL_DIR=%3 -dPGDIR="%PGDIR%" -dBUILDTREE="%BUILDTREE%" -dBRANDED=%BRANDED% -dBRANDINGDIR="%BRANDINGDIR%" -dAPPVENDOR="%APPVENDOR%" -dAPPNAME="%APPNAME%" -dAPPKEYWORDS="%APPKEYWORDS%" -dAPPCOMMENTS="%APPCOMMENTS%" -dAPPDESCRIPTION="%APPDESCRIPTION%" -dAPPVERSION="%1" -dSYSTEM32DIR="%SystemRoot%\System32" -dPFILESDIR="%ProgramFiles%" src/pgadmin3.wxs
 IF ERRORLEVEL 1 GOTO ERR_HANDLER
 
 "%WIX%\bin\light" -sice:ICE03 -sice:ICE25 -sice:ICE82 -sw1101 -nologo -ext WixUIExtension -cultures:en-us pgadmin3.wixobj
@@ -71,7 +71,7 @@ GOTO EXIT
 
 :ERR_USAGE
 echo Invalid command line options.
-echo Usage: "Make.bat <Major.Minor version number> <Platform toolset version>"
+echo Usage: "Make.bat <Major.Minor version number> <Platform toolset version> <VCToolsRedistInstallDir>"
 echo        "Make.bat REGENGUIDS"
 echo.
 GOTO EXIT

--- a/pkg/win32/Make.bat
+++ b/pkg/win32/Make.bat
@@ -9,9 +9,7 @@ SET APPNAME=pgAdmin III
 SET APPKEYWORDS=PostgreSQL, pgAdmin
 SET APPCOMMENTS=PostgreSQL Tools
 SET APPDESCRIPTION=Management and administration tools for the PostgreSQL DBMS
-IF NOT (%WIXDIR%)==() GOTO DONE_WIXDIR
-SET WIXDIR="C:\Program Files (x86)\Windows Installer XML v3\bin"
-:DONE_WIXDIR
+IF "%WIX%"=="" GOTO ERR_NOWIX
 
 SET BUILDTREE="../.."
 
@@ -56,10 +54,10 @@ if "%2"=="" GOTO ERR_USAGE
 echo.
 echo Building %APPNAME% Installer...
 
-%WIXDIR%\candle -nologo -dWXDIR="%WXWIN%" -dPLATFORM_TOOLSET_VERSION=%2 -dPGDIR="%PGDIR%" -dBUILDTREE="%BUILDTREE%" -dBRANDED=%BRANDED% -dBRANDINGDIR="%BRANDINGDIR%" -dAPPVENDOR="%APPVENDOR%" -dAPPNAME="%APPNAME%" -dAPPKEYWORDS="%APPKEYWORDS%" -dAPPCOMMENTS="%APPCOMMENTS%" -dAPPDESCRIPTION="%APPDESCRIPTION%" -dAPPVERSION="%1" -dSYSTEM32DIR="%SystemRoot%\System32" -dPFILESDIR="%ProgramFiles%" src/pgadmin3.wxs
+"%WIX%\bin\candle" -nologo -dWXDIR="%WXWIN%" -dPLATFORM_TOOLSET_VERSION=%2 -dPGDIR="%PGDIR%" -dBUILDTREE="%BUILDTREE%" -dBRANDED=%BRANDED% -dBRANDINGDIR="%BRANDINGDIR%" -dAPPVENDOR="%APPVENDOR%" -dAPPNAME="%APPNAME%" -dAPPKEYWORDS="%APPKEYWORDS%" -dAPPCOMMENTS="%APPCOMMENTS%" -dAPPDESCRIPTION="%APPDESCRIPTION%" -dAPPVERSION="%1" -dSYSTEM32DIR="%SystemRoot%\System32" -dPFILESDIR="%ProgramFiles%" src/pgadmin3.wxs
 IF ERRORLEVEL 1 GOTO ERR_HANDLER
 
-%WIXDIR%\light -sice:ICE03 -sice:ICE25 -sice:ICE82 -sw1101 -nologo -ext WixUIExtension -cultures:en-us pgadmin3.wixobj
+"%WIX%\bin\light" -sice:ICE03 -sice:ICE25 -sice:ICE82 -sw1101 -nologo -ext WixUIExtension -cultures:en-us pgadmin3.wixobj
 IF ERRORLEVEL 1 GOTO ERR_HANDLER
 
 echo.
@@ -76,6 +74,11 @@ echo Invalid command line options.
 echo Usage: "Make.bat <Major.Minor version number> <Platform toolset version>"
 echo        "Make.bat REGENGUIDS"
 echo.
+GOTO EXIT
+
+:ERR_NOWIX
+echo WiX directory not configured!
+echo Please make sure the environment variable WIX points to the correct location.
 GOTO EXIT
 
 

--- a/pkg/win32/src/pgadmin3.wxs
+++ b/pkg/win32/src/pgadmin3.wxs
@@ -47,7 +47,7 @@
                             <File Id="core_libs.wxmsw30u_xrc_vc$(var.PLATFORM_TOOLSET_VERSION).dll" Name="wxmsw30u_xrc_vc$(var.PLATFORM_TOOLSET_VERSION).dll" DiskId="1" Source="$(var.WXDIR)/lib/vc$(var.PLATFORM_TOOLSET_VERSION)_dll/wxmsw30u_xrc_vc$(var.PLATFORM_TOOLSET_VERSION).dll" DefaultLanguage="0" />
                         </Component>
 
-                        <Merge Id="CRT" Language="0" SourceFile="$(env.ProgramFiles)\Common Files\Merge Modules\Microsoft_VC120_CRT_x86.msm" DiskId="1" />
+                        <Merge Id="CRT" Language="0" SourceFile="$(var.VC_TOOLS_REDIST_INSTALL_DIR)\MergeModules\Microsoft_VC$(var.PLATFORM_TOOLSET_VERSION)_CRT_x86.msm" DiskId="1" />
 
                         <Component Id="pgadmin_exes" Guid="{5EA77DAF-4AD7-4F9F-AC4B-C21B5299E8F8}">
                             <File Id="pgadmin_exes.pgadmin3.exe" Name="pgadmin3.exe" DiskId="1" Source="$(var.BUILDTREE)/pgadmin/Release/pgAdmin3.exe" KeyPath="yes" />

--- a/pkg/win32/src/pgadmin3.wxs
+++ b/pkg/win32/src/pgadmin3.wxs
@@ -322,6 +322,7 @@
                             <File Id="postgresql_exes.pg_dump.exe" Name="pg_dump.exe" DiskId="1" Source="$(var.PGDIR)/bin/pg_dump.exe" />
                             <File Id="postgresql_exes.pg_dumpall.exe" Name="pg_dumpall.exe" DiskId="1" Source="$(var.PGDIR)/bin/pg_dumpall.exe" />
                             <File Id="postgresql_exes.pg_restore.exe" Name="pg_restore.exe" DiskId="1" Source="$(var.PGDIR)/bin/pg_restore.exe" />
+                            <File Id="postgresql_exes.zlib1.dll" Name="zlib1.dll" DiskId="1" Source="$(var.PGDIR)/bin/zlib1.dll" />
                         </Component>
 
                         <Directory Id="i18nDir" Name="i18n">


### PR DESCRIPTION
This PR fixes these major issues with building the installer (MSI-package) on Windows:
* missing library for an optional feature
* overlapping directories of some *.vcxproj files leading to missing files when building
* outdated version of the installer tool
* bundling of an outdated version of the C++-runtime

Now that these issues are fixed the installer build works. This PR therefore also contains some commits to make the github workflow include also the release mode. A release mode build includes building the documentation and the installer.

The bundling of the correct version of the C++-runtime requires VS2019, so this PR adjusts the instructions for developers and the virtual machine used by the github workflow. Hopefully we can come up with a solution so that we can support VS2022 again.