### PR TITLE
Allow SCRAM password hashing

### DIFF
--- a/.github/workflows/msbuild.yml
+++ b/.github/workflows/msbuild.yml
@@ -75,7 +75,7 @@ jobs:
       working-directory: ${{env.GITHUB_WORKSPACE}}
       shell: pwsh
       run: |
-        Invoke-WebRequest -Uri "https://get.enterprisedb.com/postgresql/postgresql-9.2.24-1-windows-binaries.zip?ls=Crossover&type=Crossover" -OutFile postgres-binaries.zip
+        Invoke-WebRequest -Uri "https://get.enterprisedb.com/postgresql/postgresql-10.19-1-windows-binaries.zip?ls=Crossover&type=Crossover" -OutFile postgres-binaries.zip
         7z.exe x postgres-binaries.zip -o${{env.PGDIR}}\..
 
     - name: Set up Visual Studio shell

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -31,12 +31,15 @@ Key to developers
 - MH   Magnus Hagander
 - GL   Guillaume Lelarge
 - AV   Ashesh Vashi
+- SD   Sebastian Dietrich
 
 Changes
 -------
 
 Date       Dev Ver     Change details
 ---------- --- ------  --------------
+2022-02-13 SD  1.24.0  Use the server-default password hashing algorithm
+                       instead of always using MD5
 2016-06-13 DP  1.22.2  Include the Negator when reverse engineering SQL for
                        operators [Julien Rouhaud]
 2016-03-22 DP  1.22.2  Fix the psql plugin command on OSX to work more

--- a/INSTALL
+++ b/INSTALL
@@ -151,7 +151,6 @@ You will need:
   If you want to build the documentation and/or the installer you additionally
   need the package "Source Code".
 - libssh2 1.10.0 or above from https://www.libssh2.org/
-- PostgreSQL 9.2.24 (binary distribution) from http://www.postgresql.org/
 - PostgreSQL 10.19 or later (binary distribution) from http://www.postgresql.org/
 - Sphinx 1.0 or above from http://sphinx.pocoo.org/
 - Microsoft HTML Help Workshop
@@ -170,7 +169,7 @@ Building:
        echo BUILD = release>> ..\..\build\msw\config.vc
        nmake -f makefile.vc COMPILER_VERSION=142
 
-3) Install PostgreSQL 9.2.24 to a convenient location pointed to by the %PGDIR%
+3) Unpack PostgreSQL to a convenient location pointed to by the %PGDIR%
    environment variable.
    
 4) Unpack, compile and install libssh2 to a convenient location pointed to by the
@@ -185,7 +184,4 @@ Building:
    prerequisite DLLs from the wxWidgets and PostgreSQL installations into the
    directory where the EXE file is located, or have those directories in your
    path.
-   To actually connect to a Postgres-Server higher than 11 that is using SCRAM-
-   authentication you need the "libpq.dll" from the Postgres 10.19 (or later)
-   package.
 

--- a/INSTALL
+++ b/INSTALL
@@ -20,7 +20,7 @@ You will need:
 - libxml2 2.6.18 or above from http://www.xmlsoft.org/
 - libxslt 1.1.x or above from http://www.xmlsoft.org/
 - libssh2 1.10.0 or above from http://www.libssh2.org/
-- PostgreSQL 8.4 or above from http://www.postgresql.org/
+- PostgreSQL 10.x or above from http://www.postgresql.org/
 - Sphinx 1.0 or above from http://sphinx.pocoo.org/
 
 Building:
@@ -77,7 +77,7 @@ You will need:
 - libxml2 2.6.18 or above from http://www.xmlsoft.org/
 - libxslt 1.1.x or above from http://www.xmlsoft.org/
 - libssh2 1.10.0 or above from http://www.libssh2.org/
-- PostgreSQL 8.4 or above from http://www.postgresql.org/
+- PostgreSQL 10.x or above from http://www.postgresql.org/
 - Sphinx 1.0 or above from http://sphinx.pocoo.org/
 
 Building:

--- a/pgadmin/db/pgConn.cpp
+++ b/pgadmin/db/pgConn.cpp
@@ -588,7 +588,7 @@ wxString pgConn::EncryptPassword(const wxString &user, const wxString &password)
 	char *chrPassword;
 	wxString strPassword;
 
-	chrPassword = PQencryptPassword(password.mb_str(*conv), user.mb_str(*conv));
+	chrPassword = PQencryptPasswordConn(conn, password.mb_str(*conv), user.mb_str(*conv), NULL);
 	strPassword = wxString::FromAscii(chrPassword);
 
 	PQfreemem(chrPassword);

--- a/pkg/win32/src/pgadmin3.wxs
+++ b/pkg/win32/src/pgadmin3.wxs
@@ -30,13 +30,14 @@
                     <Directory Id="VersionDir" Name="$(var.APPVERSION)">
 
                         <Component Id="core_libs" Guid="{3CF23B03-AE55-4FAB-B03B-7F8454F8802F}">
-                            <File Id="core_libs.libeay32.dll" Name="libeay32.dll" DiskId="1" Source="$(var.PGDIR)/bin/libeay32.dll" />
-                            <File Id="core_libs.libintl.dll" Name="libintl.dll" DiskId="1" Source="$(var.PGDIR)/bin/libintl.dll" />
+                            <File Id="core_libs.libcrypto_1_1.dll" Name="libcrypto-1_1.dll" DiskId="1" Source="$(var.PGDIR)/bin/libcrypto-1_1.dll" />
+                            <File Id="core_libs.libintl_8.dll" Name="libintl-8.dll" DiskId="1" Source="$(var.PGDIR)/bin/libintl-8.dll" />
                             <File Id="core_libs.libpq.dll" Name="libpq.dll" DiskId="1" Source="$(var.PGDIR)/bin/libpq.dll" />
                             <File Id="core_libs.libxml2.dll" Name="libxml2.dll" DiskId="1" Source="$(var.PGDIR)/bin/libxml2.dll" />
                             <File Id="core_libs.libxslt.dll" Name="libxslt.dll" DiskId="1" Source="$(var.PGDIR)/bin/libxslt.dll" />
-                            <File Id="core_libs.ssleay32.dll" Name="ssleay32.dll" DiskId="1" Source="$(var.PGDIR)/bin/ssleay32.dll" />
+                            <File Id="core_libs.libssl_1_1.dll" Name="libssl-1_1.dll" DiskId="1" Source="$(var.PGDIR)/bin/libssl-1_1.dll" />
                             <File Id="core_libs.libssh2.dll" Name="libssh2.dll" DiskId="1" Source="$(var.LIBSSH2DIR)/bin/libssh2.dll" />
+                            <File Id="core_libs.libiconv_2.dll" Name="libiconv-2.dll" DiskId="1" Source="$(var.PGDIR)/bin/libiconv-2.dll" />
                             <File Id="core_libs.wxbase30u_net_vc$(var.PLATFORM_TOOLSET_VERSION).dll" Name="wxbase30u_net_vc$(var.PLATFORM_TOOLSET_VERSION).dll" DiskId="1" Source="$(var.WXDIR)/lib/vc$(var.PLATFORM_TOOLSET_VERSION)_dll/wxbase30u_net_vc$(var.PLATFORM_TOOLSET_VERSION).dll" DefaultLanguage="0" />
                             <File Id="core_libs.wxbase30u_vc$(var.PLATFORM_TOOLSET_VERSION).dll" Name="wxbase30u_vc$(var.PLATFORM_TOOLSET_VERSION).dll" DiskId="1" Source="$(var.WXDIR)/lib/vc$(var.PLATFORM_TOOLSET_VERSION)_dll/wxbase30u_vc$(var.PLATFORM_TOOLSET_VERSION).dll" DefaultLanguage="0" />
                             <File Id="core_libs.wxbase30u_xml_vc$(var.PLATFORM_TOOLSET_VERSION).dll" Name="wxbase30u_xml_vc$(var.PLATFORM_TOOLSET_VERSION).dll" DiskId="1" Source="$(var.WXDIR)/lib/vc$(var.PLATFORM_TOOLSET_VERSION)_dll/wxbase30u_xml_vc$(var.PLATFORM_TOOLSET_VERSION).dll" DefaultLanguage="0" />


### PR DESCRIPTION
This PR enables the use of the newer and safer SCRAM password hashing method instead of MD5. Now the algorithm that is set as the default by the server is used whereas before MD5 was used even if the server had defined SCRAM as the default.

To be able to do so, the minimum requirement for PostgreSQL is raised to version 10.x, because SCRAM was introduced in [version 10 of PostgreSQL](https://www.postgresql.org/docs/release/10.0/).